### PR TITLE
Refactor IIFE as a private member

### DIFF
--- a/packages/copilot-studio-direct-to-engine-chat-adapter/CHANGELOG.md
+++ b/packages/copilot-studio-direct-to-engine-chat-adapter/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added new subprotocol for published bot, by [@compulim](https://github.com/compulim)
-- Added emitStartConversationEvent option to fromTurnBasedChatAdapterAPI [@tdurnford](https://github.com/tdurnford)
+- Added `emitStartConversationEvent` option to `fromTurnBasedChatAdapterAPI` [@tdurnford](https://github.com/tdurnford)
 - Added give up my turn, by [@compulim](https://github.com/compulim), in PR [#62](https://github.com/compulim/conversational-ai-chat-sdk/pull/62)
+- (Experimental) Added experimental /subscribe endpoint, by [@compulim](https://github.com/compulim), in PR [#62](https://github.com/compulim/conversational-ai-chat-sdk/pull/62) and [#64](https://github.com/compulim/conversational-ai-chat-sdk/pull/64)
 
 ## [0.0.0] - 2023-08-19
 


### PR DESCRIPTION
IIFE is accidentally removed by webpack@4 + terser@4.8.1. Unsure the root cause, but refactoring IIFE as a private member help workaround their issue.