### PR TITLE
Fixed race conditions between give up my turn and post activity

### DIFF
--- a/packages/copilot-studio-direct-to-engine-chat-adapter/src/tests/toDirectLineJS/postActivity.blobContentURL.spec.ts
+++ b/packages/copilot-studio-direct-to-engine-chat-adapter/src/tests/toDirectLineJS/postActivity.blobContentURL.spec.ts
@@ -1,3 +1,4 @@
+import { waitFor } from '@testduet/wait-for';
 import { type ConnectionStatus } from 'botframework-directlinejs';
 import { type Observable } from 'iter-fest';
 
@@ -92,6 +93,10 @@ describe('with a TurnGenerator', () => {
         });
 
         describe('should call next turn', () => {
+          // After postActivity() and before nextTurn(), we will read the blob asynchronously.
+          // We are using waitFor here to wait until the blob has read completed.
+          beforeEach(() => waitFor(() => expect(nextTurn).toHaveBeenCalledTimes(2)));
+
           test('once', () => expect(nextTurn).toHaveBeenCalledTimes(2));
 
           test('with the attachment of ArrayBuffer', () =>

--- a/packages/copilot-studio-direct-to-engine-chat-adapter/src/tests/toDirectLineJS/postActivity.giveUp.spec.ts
+++ b/packages/copilot-studio-direct-to-engine-chat-adapter/src/tests/toDirectLineJS/postActivity.giveUp.spec.ts
@@ -1,12 +1,10 @@
 import { type ConnectionStatus } from 'botframework-directlinejs';
-import { type Observable } from 'iter-fest';
 
 import { type TurnGenerator } from '../../createHalfDuplexChatAdapter';
 import DeferredQueue from '../../private/DeferredQueue';
 import { type JestMockOf } from '../../private/types/JestMockOf';
 import toDirectLineJS from '../../toDirectLineJS';
 import { type Activity } from '../../types/Activity';
-import { type DirectLineJSBotConnection } from '../../types/DirectLineJSBotConnection';
 
 const END_TURN = Symbol('END_TURN');
 

--- a/packages/copilot-studio-direct-to-engine-chat-adapter/src/tests/toDirectLineJS/postActivity.giveUp.spec.ts
+++ b/packages/copilot-studio-direct-to-engine-chat-adapter/src/tests/toDirectLineJS/postActivity.giveUp.spec.ts
@@ -102,6 +102,22 @@ describe('with a TurnGenerator', () => {
             });
           });
         });
+
+        describe('when giveUp() is called before turn finished', () => {
+          beforeEach(() => directLineJS.giveUp());
+
+          describe('when turn finished', () => {
+            beforeEach(() => incomingActivityQueue.push(END_TURN));
+
+            test('should not call next turn', () => expect(nextTurn).toHaveBeenCalledTimes(2));
+
+            describe('when giveUp() is called again', () => {
+              beforeEach(() => directLineJS.giveUp());
+
+              test('should call next turn', () => expect(nextTurn).toHaveBeenCalledTimes(3));
+            });
+          });
+        });
       });
     });
   });

--- a/packages/copilot-studio-direct-to-engine-chat-adapter/src/tests/toDirectLineJS/postActivity.giveUp.spec.ts
+++ b/packages/copilot-studio-direct-to-engine-chat-adapter/src/tests/toDirectLineJS/postActivity.giveUp.spec.ts
@@ -1,0 +1,110 @@
+import { type ConnectionStatus } from 'botframework-directlinejs';
+import { type Observable } from 'iter-fest';
+
+import { type TurnGenerator } from '../../createHalfDuplexChatAdapter';
+import DeferredQueue from '../../private/DeferredQueue';
+import { type JestMockOf } from '../../private/types/JestMockOf';
+import toDirectLineJS from '../../toDirectLineJS';
+import { type Activity } from '../../types/Activity';
+import { type DirectLineJSBotConnection } from '../../types/DirectLineJSBotConnection';
+
+const END_TURN = Symbol('END_TURN');
+
+describe('with a TurnGenerator', () => {
+  let activityObserver: JestMockOf<(activity: Activity) => void>;
+  let connectionStatusObserver: JestMockOf<(connectionStatus: ConnectionStatus) => void>;
+  let directLineJS: ReturnType<typeof toDirectLineJS>;
+  let incomingActivityQueue: DeferredQueue<Activity | typeof END_TURN>;
+  let turnGenerator: TurnGenerator;
+  let nextTurn: JestMockOf<(activity?: Activity | undefined) => TurnGenerator>;
+
+  beforeEach(() => {
+    incomingActivityQueue = new DeferredQueue();
+
+    nextTurn = jest.fn<TurnGenerator, [Activity | undefined]>(() => {
+      return (async function* () {
+        for (;;) {
+          const activity = await incomingActivityQueue.promise;
+
+          if (activity === END_TURN) {
+            break;
+          } else {
+            yield activity;
+          }
+        }
+
+        return nextTurn;
+      })();
+    });
+
+    turnGenerator = nextTurn();
+
+    activityObserver = jest.fn();
+    connectionStatusObserver = jest.fn();
+
+    directLineJS = toDirectLineJS(turnGenerator);
+    directLineJS.connectionStatus$.subscribe(connectionStatusObserver);
+
+    directLineJS.activity$.subscribe(activityObserver);
+  });
+
+  describe('when greeting turn ended', () => {
+    beforeEach(() => incomingActivityQueue.push(END_TURN));
+
+    test('should not call next turn', () => expect(nextTurn).toHaveBeenCalledTimes(1));
+
+    describe('when 1 activity iterated', () => {
+      beforeEach(() =>
+        incomingActivityQueue.push({ from: { id: 'bot', role: 'bot' }, text: 'Hello, World!', type: 'message' })
+      );
+
+      describe('when give up the turn', () => {
+        beforeEach(() => {
+          directLineJS.giveUp();
+        });
+
+        test('should call next turn', () => expect(nextTurn).toHaveBeenCalledTimes(2));
+
+        describe('activity observer should be called', () => {
+          test('once', () => expect(activityObserver).toHaveBeenCalledTimes(1));
+          test('with the activity', () =>
+            expect(activityObserver).toHaveBeenLastCalledWith(
+              expect.objectContaining({
+                from: { id: 'bot', role: 'bot' },
+                text: 'Hello, World!',
+                type: 'message'
+              })
+            ));
+        });
+
+        describe('post activity before turn has finished', () => {
+          let postActivityObserver: JestMockOf<() => void>;
+
+          beforeEach(() => {
+            postActivityObserver = jest.fn();
+
+            directLineJS
+              .postActivity({ from: { id: 'user', role: 'user' }, text: 'User 1', type: 'message' })
+              .subscribe(postActivityObserver);
+          });
+
+          test('should not call next turn', () => expect(nextTurn).toHaveBeenCalledTimes(2));
+
+          describe('when turn finished', () => {
+            beforeEach(() => incomingActivityQueue.push(END_TURN));
+
+            describe('should call next turn', () => {
+              test('once', () => expect(nextTurn).toHaveBeenCalledTimes(3));
+              test('to post activity', () =>
+                expect(nextTurn).toHaveBeenLastCalledWith({
+                  from: { id: 'user', role: 'user' },
+                  text: 'User 1',
+                  type: 'message'
+                }));
+            });
+          });
+        });
+      });
+    });
+  });
+});

--- a/packages/copilot-studio-direct-to-engine-chat-adapter/src/toDirectLineJS.ts
+++ b/packages/copilot-studio-direct-to-engine-chat-adapter/src/toDirectLineJS.ts
@@ -126,6 +126,8 @@ export default function toDirectLineJS(
           } else {
             giveUpDeferred = promiseWithResolvers<void>();
 
+            // TODO: Temporarily allowing `executeTurn()` to send `undefined` activity, we should change the `executeTurn` signature later.
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             turnGenerator = executeTurn(undefined as any);
           }
         }

--- a/packages/copilot-studio-direct-to-engine-chat-adapter/src/toDirectLineJS.ts
+++ b/packages/copilot-studio-direct-to-engine-chat-adapter/src/toDirectLineJS.ts
@@ -154,6 +154,7 @@ export default function toDirectLineJS(
       giveUpDeferred.resolve();
     },
     postActivity: (activity: Activity) =>
+      // TODO: Throw exception if the postActivity() is already resolved because the current postActivity() will be lost.
       shareObservable(
         new Observable<ActivityId>(observer =>
           postActivityDeferred.resolve(

--- a/packages/copilot-studio-direct-to-engine-chat-adapter/src/toDirectLineJS.ts
+++ b/packages/copilot-studio-direct-to-engine-chat-adapter/src/toDirectLineJS.ts
@@ -26,8 +26,11 @@ function once(fn: () => Promise<void> | void): () => Promise<void> | void {
   };
 }
 
-export default function toDirectLineJS(halfDuplexChatAdapter: TurnGenerator): DirectLineJSBotConnection {
+export default function toDirectLineJS(
+  halfDuplexChatAdapter: TurnGenerator
+): DirectLineJSBotConnection & { giveUp: () => void } {
   let nextSequenceId = 0;
+  let giveUpDeferred = promiseWithResolvers<void>();
   let postActivityDeferred =
     promiseWithResolvers<readonly [Activity, (id: ActivityId) => void, (error: unknown) => void]>();
 
@@ -66,51 +69,52 @@ export default function toDirectLineJS(halfDuplexChatAdapter: TurnGenerator): Di
           await handleAcknowledgementOnce();
 
           const executeTurn = iterator.lastValue();
-          const [activity, resolvePostActivity, rejectPostActivity] = await postActivityDeferred.promise;
+          const result = await Promise.race([postActivityDeferred.promise, giveUpDeferred.promise]);
 
-          try {
-            postActivityDeferred = promiseWithResolvers();
+          if (result) {
+            const [activity, resolvePostActivity, rejectPostActivity] = result;
 
-            // Patch `activity.attachments[].contentUrl` into Data URI if it was Blob URL.
-            if (activity && activity.type === 'message' && activity.attachments) {
-              activity.attachments = await Promise.all(
-                activity.attachments.map(async (attachment: Attachment) => {
-                  if ('contentUrl' in attachment) {
-                    const { contentUrl } = attachment;
+            try {
+              postActivityDeferred = promiseWithResolvers();
 
-                    // Ignore malformed URL.
-                    if (onErrorResumeNext(() => new URL(contentUrl).protocol) === 'blob:') {
-                      // Only allow fetching blob URLs.
-                      const res = await fetch(contentUrl);
+              // Patch `activity.attachments[].contentUrl` into Data URI if it was Blob URL.
+              if (activity && activity.type === 'message' && activity.attachments) {
+                activity.attachments = await Promise.all(
+                  activity.attachments.map(async (attachment: Attachment) => {
+                    if ('contentUrl' in attachment) {
+                      const { contentUrl } = attachment;
 
-                      if (!res.ok) {
-                        throw new Error('Failed to fetch attachment of blob URL.');
+                      // Ignore malformed URL.
+                      if (onErrorResumeNext(() => new URL(contentUrl).protocol) === 'blob:') {
+                        // Only allow fetching blob URLs.
+                        const res = await fetch(contentUrl);
+
+                        if (!res.ok) {
+                          throw new Error('Failed to fetch attachment of blob URL.');
+                        }
+
+                        // FileReader.readAsDataURL() is not available in Node.js.
+                        return Object.freeze({
+                          ...attachment,
+                          contentUrl: `data:${res.headers.get('content-type') || ''};base64,${base64Encode(
+                            await res.arrayBuffer()
+                          )}`
+                        });
                       }
-
-                      // FileReader.readAsDataURL() is not available in Node.js.
-                      return Object.freeze({
-                        ...attachment,
-                        contentUrl: `data:${res.headers.get('content-type') || ''};base64,${base64Encode(
-                          await res.arrayBuffer()
-                        )}`
-                      });
                     }
-                  }
 
-                  return attachment;
-                })
-              );
+                    return attachment;
+                  })
+                );
+              }
+
+              turnGenerator = executeTurn(activity);
+            } catch (error) {
+              rejectPostActivity(error);
+
+              throw error;
             }
 
-            turnGenerator = executeTurn(activity);
-          } catch (error) {
-            rejectPostActivity(error);
-
-            throw error;
-          }
-
-          // TODO: Add a test to make sure "give up my turn" will not echo back.
-          if (activity) {
             // Except "give up my turn", we will generate the activity ID and echoback the activity only when the first incoming activity arrived.
             // This make sure the bot acknowledged the outgoing activity before we echoback the activity.
             handleAcknowledgementOnce = once(() => {
@@ -119,6 +123,10 @@ export default function toDirectLineJS(halfDuplexChatAdapter: TurnGenerator): Di
               observer.next(patchActivity({ ...activity, id: activityId }));
               resolvePostActivity(activityId);
             });
+          } else {
+            giveUpDeferred = promiseWithResolvers<void>();
+
+            turnGenerator = executeTurn(undefined as any);
           }
         }
       } catch (error) {
@@ -136,6 +144,9 @@ export default function toDirectLineJS(halfDuplexChatAdapter: TurnGenerator): Di
     connectionStatus$: shareObservable(connectionStatusDeferredObservable.observable),
     end() {
       // Half-duplex connection does not requires implicit closing.
+    },
+    giveUp() {
+      giveUpDeferred.resolve();
     },
     postActivity: (activity: Activity) =>
       shareObservable(

--- a/packages/copilot-studio-direct-to-engine-chat-adapter/src/toDirectLineJS.ts
+++ b/packages/copilot-studio-direct-to-engine-chat-adapter/src/toDirectLineJS.ts
@@ -65,6 +65,9 @@ export default function toDirectLineJS(
             observer.next(patchActivity(activity));
           }
 
+          // All activities should be retrieved by now, we will start accepting "give up" signal from this point of time.
+          giveUpDeferred = promiseWithResolvers<void>();
+
           // If no activities received from bot, we should still acknowledge.
           await handleAcknowledgementOnce();
 

--- a/packages/powerva-chat-adapter/CHANGELOG.md
+++ b/packages/powerva-chat-adapter/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added new subprotocol for published bot, by [@compulim](https://github.com/compulim)
 - Added emitStartConversationEvent option to fromTurnBasedChatAdapterAPI [@tdurnford](https://github.com/tdurnford)
 - Added give up my turn, by [@compulim](https://github.com/compulim), in PR [#62](https://github.com/compulim/conversational-ai-chat-sdk/pull/62)
+   - Fixed race conditions between give up my turn and post activity, by [@compulim](https://github.com/compulim), in PR [#65](https://github.com/compulim/conversational-ai-chat-sdk/pull/65)
 
 ## [0.0.0] - 2023-08-19
 


### PR DESCRIPTION
We are adding a new `giveUp()` function to the return value of `toDirectLineJS()`. If the turn is on user side, calling this function will give up the turn, otherwise, it will be no-op. I.e. give up turn while the turn is on bot side will be no-op as we do not have the turn.

## Repro

- On every activity coming from `/subscribe`, we will call `onActivity
- `onActivity` will trigger upstream to "give up my turn"
- While iterating activities asynchronously, furthermore activities coming from `/subscribe`
   - Furthermore `onActivity` is triggered
- As every "give up my turn" is literally a `postActivity(undefined)`, the `postActivityDeferred` will be resolved
- If there are any `postActivity()` is called in the meanwhile, it will be ignored as the `postActivityDeferred` is already resolved

### Expectations

- EXPECT: The `postActivity()` should not be ignored
- ACTUAL: The `postActivity()` call is ignored
