### PR TITLE
Add */*;q=0.8 to accept header

### DIFF
--- a/packages/copilot-studio-direct-to-engine-chat-adapter/CHANGELOG.md
+++ b/packages/copilot-studio-direct-to-engine-chat-adapter/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `emitStartConversationEvent` option to `fromTurnBasedChatAdapterAPI` [@tdurnford](https://github.com/tdurnford)
 - Added give up my turn, by [@compulim](https://github.com/compulim), in PR [#62](https://github.com/compulim/conversational-ai-chat-sdk/pull/62)
+   - Fixed race conditions between give up my turn and post activity, by [@compulim](https://github.com/compulim), in PR [#65](https://github.com/compulim/conversational-ai-chat-sdk/pull/65)
 - (Experimental) Added experimental /subscribe endpoint, by [@compulim](https://github.com/compulim), in PR [#62](https://github.com/compulim/conversational-ai-chat-sdk/pull/62) and [#64](https://github.com/compulim/conversational-ai-chat-sdk/pull/64)
 - Added `*/*;q=0.8` to accept header, by [@compulim](https://github.com/compulim), in PR [#70](https://github.com/compulim/conversational-ai-chat-sdk/pull/70)
 

--- a/packages/copilot-studio-direct-to-engine-chat-adapter/CHANGELOG.md
+++ b/packages/copilot-studio-direct-to-engine-chat-adapter/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `emitStartConversationEvent` option to `fromTurnBasedChatAdapterAPI` [@tdurnford](https://github.com/tdurnford)
 - Added give up my turn, by [@compulim](https://github.com/compulim), in PR [#62](https://github.com/compulim/conversational-ai-chat-sdk/pull/62)
 - (Experimental) Added experimental /subscribe endpoint, by [@compulim](https://github.com/compulim), in PR [#62](https://github.com/compulim/conversational-ai-chat-sdk/pull/62) and [#64](https://github.com/compulim/conversational-ai-chat-sdk/pull/64)
+- Added `*/*;q=0.8` to accept header, by [@compulim](https://github.com/compulim), in PR [#70](https://github.com/compulim/conversational-ai-chat-sdk/pull/70)
 
 ## [0.0.0] - 2023-08-19
 

--- a/packages/copilot-studio-direct-to-engine-chat-adapter/src/private/DirectToEngineChatAdapterAPI/private/APISession.ts
+++ b/packages/copilot-studio-direct-to-engine-chat-adapter/src/private/DirectToEngineChatAdapterAPI/private/APISession.ts
@@ -2,18 +2,16 @@ import { EventSourceParserStream, type ParsedEvent } from 'eventsource-parser/st
 import { asyncGeneratorWithLastValue } from 'iter-fest';
 import pRetry, { type Options as PRetryOptions } from 'p-retry';
 import { maxValue, minValue, number, parse, pipe, safeParse } from 'valibot';
-import { resolveURLWithQueryAndHash } from '../../../private/resolveURLWithQueryAndHash';
 import { parseBotResponse } from '../../../private/types/BotResponse';
 import { parseConversationId, type ConversationId } from '../../../private/types/ConversationId';
 import { type Activity } from '../../../types/Activity';
 import type { StrategyRequestInit } from '../../../types/Strategy';
 import { type Telemetry } from '../../../types/Telemetry';
-import { type Transport } from '../../../types/Transport';
 import {
   directToEngineChatAdapterAPIInitSchema,
   type DirectToEngineChatAdapterAPIInit
 } from '../DirectToEngineChatAdapterAPIInit';
-import { CHAT_ADAPTER_HEADER_NAME, CONVERSATION_ID_HEADER_NAME, CORRELATION_ID_HEADER_NAME } from './Constants';
+import { CONVERSATION_ID_HEADER_NAME } from './Constants';
 import createFetchArguments from './createFetchArguments';
 
 const MAX_CONTINUE_TURN = 999;

--- a/packages/copilot-studio-direct-to-engine-chat-adapter/src/private/DirectToEngineChatAdapterAPI/private/createFetchArguments.ts
+++ b/packages/copilot-studio-direct-to-engine-chat-adapter/src/private/DirectToEngineChatAdapterAPI/private/createFetchArguments.ts
@@ -20,7 +20,9 @@ export default function createFetchArguments(
 
   headers.set(
     'accept',
-    strategyRequestInit.transport === 'rest' ? 'application/json' : 'text/event-stream,application/json;q=0.9'
+    strategyRequestInit.transport === 'rest'
+      ? 'application/json,*/*;q=0.8'
+      : 'text/event-stream,application/json;q=0.9,*/*;q=0.8'
   );
   headers.set('content-type', 'application/json');
   headers.set(

--- a/packages/copilot-studio-direct-to-engine-chat-adapter/src/private/tests/comprehensive.spec.ts
+++ b/packages/copilot-studio-direct-to-engine-chat-adapter/src/private/tests/comprehensive.spec.ts
@@ -141,11 +141,11 @@ data: end
             if (transport === 'auto') {
               test('with header "Accept" of "text/event-stream,application/json;q=0.9"', () =>
                 expect(httpPostConversation.mock.calls[0][0].request.headers.get('accept')).toBe(
-                  'text/event-stream,application/json;q=0.9'
+                  'text/event-stream,application/json;q=0.9,*/*;q=0.8'
                 ));
             } else if (transport === 'rest') {
               test('with header "Accept" of "application/json"', () =>
-                expect(httpPostConversation.mock.calls[0][0].request.headers.get('accept')).toBe('application/json'));
+                expect(httpPostConversation.mock.calls[0][0].request.headers.get('accept')).toBe('application/json,*/*;q=0.8'));
             }
 
             test('with header "Content-Type" of "application/json"', () =>
@@ -401,12 +401,12 @@ data: end
                       if (transport === 'auto') {
                         test('with header "Accept" of "text/event-stream,application/json;q=0.9"', () =>
                           expect(httpPostExecute.mock.calls[0][0].request.headers.get('accept')).toBe(
-                            'text/event-stream,application/json;q=0.9'
+                            'text/event-stream,application/json;q=0.9,*/*;q=0.8'
                           ));
                       } else if (transport === 'rest') {
                         test('with header "Accept" of "application/json"', () =>
                           expect(httpPostExecute.mock.calls[0][0].request.headers.get('accept')).toBe(
-                            'application/json'
+                            'application/json,*/*;q=0.8'
                           ));
                       }
 

--- a/packages/copilot-studio-direct-to-engine-chat-adapter/src/private/tests/comprehensive.spec.ts
+++ b/packages/copilot-studio-direct-to-engine-chat-adapter/src/private/tests/comprehensive.spec.ts
@@ -145,7 +145,9 @@ data: end
                 ));
             } else if (transport === 'rest') {
               test('with header "Accept" of "application/json"', () =>
-                expect(httpPostConversation.mock.calls[0][0].request.headers.get('accept')).toBe('application/json,*/*;q=0.8'));
+                expect(httpPostConversation.mock.calls[0][0].request.headers.get('accept')).toBe(
+                  'application/json,*/*;q=0.8'
+                ));
             }
 
             test('with header "Content-Type" of "application/json"', () =>

--- a/packages/copilot-studio-direct-to-engine-chat-adapter/src/private/tests/failure.protocol.mismatch.spec.ts
+++ b/packages/copilot-studio-direct-to-engine-chat-adapter/src/private/tests/failure.protocol.mismatch.spec.ts
@@ -110,7 +110,9 @@ data: end
         describe('should have POST to /conversations', () => {
           test('once', () => expect(httpPostConversation).toHaveBeenCalledTimes(1));
           test('with header "Accept" of "application/json"', () =>
-            expect(httpPostConversation.mock.calls[0][0].request.headers.get('accept')).toBe('application/json,*/*;q=0.8'));
+            expect(httpPostConversation.mock.calls[0][0].request.headers.get('accept')).toBe(
+              'application/json,*/*;q=0.8'
+            ));
         });
 
         test('should throw "Protocol mismatch" error', () =>

--- a/packages/copilot-studio-direct-to-engine-chat-adapter/src/private/tests/failure.protocol.mismatch.spec.ts
+++ b/packages/copilot-studio-direct-to-engine-chat-adapter/src/private/tests/failure.protocol.mismatch.spec.ts
@@ -110,7 +110,7 @@ data: end
         describe('should have POST to /conversations', () => {
           test('once', () => expect(httpPostConversation).toHaveBeenCalledTimes(1));
           test('with header "Accept" of "application/json"', () =>
-            expect(httpPostConversation.mock.calls[0][0].request.headers.get('accept')).toBe('application/json'));
+            expect(httpPostConversation.mock.calls[0][0].request.headers.get('accept')).toBe('application/json,*/*;q=0.8'));
         });
 
         test('should throw "Protocol mismatch" error', () =>

--- a/packages/copilot-studio-direct-to-engine-chat-adapter/src/private/tests/failure.rest.noConversationId.spec.ts
+++ b/packages/copilot-studio-direct-to-engine-chat-adapter/src/private/tests/failure.rest.noConversationId.spec.ts
@@ -129,7 +129,9 @@ data: end
                 ));
             } else {
               test('with header "Accept" of "application/json"', () =>
-                expect(httpPostConversation.mock.calls[0][0].request.headers.get('accept')).toBe('application/json,*/*;q=0.8'));
+                expect(httpPostConversation.mock.calls[0][0].request.headers.get('accept')).toBe(
+                  'application/json,*/*;q=0.8'
+                ));
             }
           });
 

--- a/packages/copilot-studio-direct-to-engine-chat-adapter/src/private/tests/failure.rest.noConversationId.spec.ts
+++ b/packages/copilot-studio-direct-to-engine-chat-adapter/src/private/tests/failure.rest.noConversationId.spec.ts
@@ -125,11 +125,11 @@ data: end
             if (transport === 'auto') {
               test('with header "Accept" of "text/event-stream,application/json;q=0.9"', () =>
                 expect(httpPostConversation.mock.calls[0][0].request.headers.get('accept')).toBe(
-                  'text/event-stream,application/json;q=0.9'
+                  'text/event-stream,application/json;q=0.9,*/*;q=0.8'
                 ));
             } else {
               test('with header "Accept" of "application/json"', () =>
-                expect(httpPostConversation.mock.calls[0][0].request.headers.get('accept')).toBe('application/json'));
+                expect(httpPostConversation.mock.calls[0][0].request.headers.get('accept')).toBe('application/json,*/*;q=0.8'));
             }
           });
 

--- a/packages/copilot-studio-direct-to-engine-chat-adapter/src/private/tests/success.protocol.autoSwitch.spec.ts
+++ b/packages/copilot-studio-direct-to-engine-chat-adapter/src/private/tests/success.protocol.autoSwitch.spec.ts
@@ -111,7 +111,7 @@ data: end
           test('once', () => expect(httpPostConversation).toHaveBeenCalledTimes(1));
           test('with header "Accept" of "text/event-stream,application/json;q=0.9"', () =>
             expect(httpPostConversation.mock.calls[0][0].request.headers.get('accept')).toBe(
-              'text/event-stream,application/json;q=0.9'
+              'text/event-stream,application/json;q=0.9,*/*;q=0.8'
             ));
         });
 
@@ -160,7 +160,7 @@ data: end
                 test('once', () => expect(httpPostConversation).toHaveBeenCalledTimes(1));
                 test('with header "Accept" of "text/event-stream,application/json;q=0.9"', () =>
                   expect(httpPostConversation.mock.calls[0][0].request.headers.get('accept')).toBe(
-                    'text/event-stream,application/json;q=0.9'
+                    'text/event-stream,application/json;q=0.9,*/*;q=0.8'
                   ));
               });
 
@@ -188,7 +188,7 @@ data: end
                   test('once', () => expect(httpPostConversation).toHaveBeenCalledTimes(1));
                   test('with header "Accept" of "text/event-stream,application/json;q=0.9"', () =>
                     expect(httpPostConversation.mock.calls[0][0].request.headers.get('accept')).toBe(
-                      'text/event-stream,application/json;q=0.9'
+                      'text/event-stream,application/json;q=0.9,*/*;q=0.8'
                     ));
                 });
 

--- a/packages/copilot-studio-direct-to-engine-chat-adapter/src/tests/createHalfDuplexChatAdapter/comprehensive.spec.ts
+++ b/packages/copilot-studio-direct-to-engine-chat-adapter/src/tests/createHalfDuplexChatAdapter/comprehensive.spec.ts
@@ -140,11 +140,11 @@ data: end
             if (transport === 'auto') {
               test('with header "Accept" of "text/event-stream,application/json;q=0.9"', () =>
                 expect(httpPostConversation.mock.calls[0][0].request.headers.get('accept')).toBe(
-                  'text/event-stream,application/json;q=0.9'
+                  'text/event-stream,application/json;q=0.9,*/*;q=0.8'
                 ));
             } else if (transport === 'rest') {
               test('with header "Accept" of "application/json"', () =>
-                expect(httpPostConversation.mock.calls[0][0].request.headers.get('accept')).toBe('application/json'));
+                expect(httpPostConversation.mock.calls[0][0].request.headers.get('accept')).toBe('application/json,*/*;q=0.8'));
             }
 
             test('with header "Content-Type" of "application/json"', () =>
@@ -386,12 +386,12 @@ data: end
                       if (transport === 'auto') {
                         test('with header "Accept" of "text/event-stream,application/json;q=0.9"', () =>
                           expect(httpPostExecute.mock.calls[0][0].request.headers.get('accept')).toBe(
-                            'text/event-stream,application/json;q=0.9'
+                            'text/event-stream,application/json;q=0.9,*/*;q=0.8'
                           ));
                       } else if (transport === 'rest') {
                         test('with header "Accept" of "application/json"', () =>
                           expect(httpPostExecute.mock.calls[0][0].request.headers.get('accept')).toBe(
-                            'application/json'
+                            'application/json,*/*;q=0.8'
                           ));
                       }
 

--- a/packages/copilot-studio-direct-to-engine-chat-adapter/src/tests/createHalfDuplexChatAdapter/comprehensive.spec.ts
+++ b/packages/copilot-studio-direct-to-engine-chat-adapter/src/tests/createHalfDuplexChatAdapter/comprehensive.spec.ts
@@ -144,7 +144,9 @@ data: end
                 ));
             } else if (transport === 'rest') {
               test('with header "Accept" of "application/json"', () =>
-                expect(httpPostConversation.mock.calls[0][0].request.headers.get('accept')).toBe('application/json,*/*;q=0.8'));
+                expect(httpPostConversation.mock.calls[0][0].request.headers.get('accept')).toBe(
+                  'application/json,*/*;q=0.8'
+                ));
             }
 
             test('with header "Content-Type" of "application/json"', () =>

--- a/packages/copilot-studio-direct-to-engine-chat-adapter/src/tests/endToEnd/comprehensive.spec.ts
+++ b/packages/copilot-studio-direct-to-engine-chat-adapter/src/tests/endToEnd/comprehensive.spec.ts
@@ -195,7 +195,9 @@ data: end
                 ));
             } else if (transport === 'rest') {
               test('with header "Accept" of "application/json"', () =>
-                expect(httpPostConversation.mock.calls[0][0].request.headers.get('accept')).toBe('application/json,*/*;q=0.8'));
+                expect(httpPostConversation.mock.calls[0][0].request.headers.get('accept')).toBe(
+                  'application/json,*/*;q=0.8'
+                ));
             }
 
             test('with header "Content-Type" of "application/json"', () =>
@@ -419,7 +421,9 @@ data: end
                     ));
                 } else if (transport === 'rest') {
                   test('with header "Accept" of "application/json"', () =>
-                    expect(httpPostExecute.mock.calls[0][0].request.headers.get('accept')).toBe('application/json,*/*;q=0.8'));
+                    expect(httpPostExecute.mock.calls[0][0].request.headers.get('accept')).toBe(
+                      'application/json,*/*;q=0.8'
+                    ));
                 }
 
                 test('with header "Content-Type" of "application/json"', () =>

--- a/packages/copilot-studio-direct-to-engine-chat-adapter/src/tests/endToEnd/comprehensive.spec.ts
+++ b/packages/copilot-studio-direct-to-engine-chat-adapter/src/tests/endToEnd/comprehensive.spec.ts
@@ -191,11 +191,11 @@ data: end
             if (transport === 'auto') {
               test('with header "Accept" of "text/event-stream,application/json;q=0.9"', () =>
                 expect(httpPostConversation.mock.calls[0][0].request.headers.get('accept')).toBe(
-                  'text/event-stream,application/json;q=0.9'
+                  'text/event-stream,application/json;q=0.9,*/*;q=0.8'
                 ));
             } else if (transport === 'rest') {
               test('with header "Accept" of "application/json"', () =>
-                expect(httpPostConversation.mock.calls[0][0].request.headers.get('accept')).toBe('application/json'));
+                expect(httpPostConversation.mock.calls[0][0].request.headers.get('accept')).toBe('application/json,*/*;q=0.8'));
             }
 
             test('with header "Content-Type" of "application/json"', () =>
@@ -415,11 +415,11 @@ data: end
                 if (transport === 'auto') {
                   test('with header "Accept" of "text/event-stream,application/json;q=0.9"', () =>
                     expect(httpPostExecute.mock.calls[0][0].request.headers.get('accept')).toBe(
-                      'text/event-stream,application/json;q=0.9'
+                      'text/event-stream,application/json;q=0.9,*/*;q=0.8'
                     ));
                 } else if (transport === 'rest') {
                   test('with header "Accept" of "application/json"', () =>
-                    expect(httpPostExecute.mock.calls[0][0].request.headers.get('accept')).toBe('application/json'));
+                    expect(httpPostExecute.mock.calls[0][0].request.headers.get('accept')).toBe('application/json,*/*;q=0.8'));
                 }
 
                 test('with header "Content-Type" of "application/json"', () =>
@@ -654,12 +654,12 @@ data: end
                     if (transport === 'auto') {
                       test('with header "Accept" of "text/event-stream,application/json;q=0.9"', () =>
                         expect(httpPostExecute.mock.calls[1][0].request.headers.get('accept')).toBe(
-                          'text/event-stream,application/json;q=0.9'
+                          'text/event-stream,application/json;q=0.9,*/*;q=0.8'
                         ));
                     } else if (transport === 'rest') {
                       test('with header "Accept" of "application/json"', () =>
                         expect(httpPostExecute.mock.calls[1][0].request.headers.get('accept')).toBe(
-                          'application/json'
+                          'application/json,*/*;q=0.8'
                         ));
                     }
 


### PR DESCRIPTION
## Changelog

### Added

- Added `*/*;q=0.8` to accept header, by [@compulim](https://github.com/compulim), in PR [#70](https://github.com/compulim/conversational-ai-chat-sdk/pull/70)
