### PR TITLE
Bump pages actions

### DIFF
--- a/.github/workflows/push-branch-to-release.yml
+++ b/.github/workflows/push-branch-to-release.yml
@@ -142,13 +142,13 @@ jobs:
         run: ls -la ./_site/
 
       - name: Configure Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
 
       - name: 'Sanity check: must have index.html'
         run: '[[ -f ./_site/index.html ]]'
 
       - name: Upload pages artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
 
   sanity-check:
     name: 'Sanity check: ${{ matrix.name }}'


### PR DESCRIPTION
Bump GitHub actions related to GitHub Pages as the version we are using is already deprecated and stopped working.