### PR TITLE
Remove some patches as the service improved

### DIFF
--- a/packages/copilot-studio-direct-to-engine-chat-adapter/src/tests/endToEnd/comprehensive.spec.ts
+++ b/packages/copilot-studio-direct-to-engine-chat-adapter/src/tests/endToEnd/comprehensive.spec.ts
@@ -231,10 +231,8 @@ data: end
 
           test('should observe the first activity', () =>
             expect(activitiesObserver).toHaveBeenNthCalledWith(1, {
-              channelData: expect.anything(),
               from: { id: 'bot' },
               text: 'Hello, World!',
-              timestamp: expect.any(String),
               type: 'message'
             }));
 
@@ -272,10 +270,8 @@ data: end
 
           test('should observe the second activity', () =>
             expect(activitiesObserver).toHaveBeenNthCalledWith(2, {
-              channelData: expect.anything(),
               from: { id: 'bot' },
               text: 'Aloha!',
-              timestamp: expect.any(String),
               type: 'message'
             }));
 
@@ -315,10 +311,8 @@ data: end
 
           test('should observe the third activity', () =>
             expect(activitiesObserver).toHaveBeenNthCalledWith(3, {
-              channelData: expect.anything(),
               from: { id: 'bot' },
               text: '您好！',
-              timestamp: expect.any(String),
               type: 'message'
             }));
 
@@ -394,11 +388,9 @@ data: end
 
               test('should observe the echoback activity', () =>
                 expect(activitiesObserver).toHaveBeenNthCalledWith(4, {
-                  channelData: expect.anything(),
                   from: { id: 'u-00001' },
                   id: postActivityObserver.mock.calls[0][0],
                   text: 'Morning.',
-                  timestamp: expect.any(String),
                   type: 'message'
                 }));
 
@@ -456,10 +448,8 @@ data: end
 
               test('should observe the fourth activity', () =>
                 expect(activitiesObserver).toHaveBeenNthCalledWith(5, {
-                  channelData: expect.anything(),
                   from: { id: 'bot' },
                   text: 'Good morning!',
-                  timestamp: expect.any(String),
                   type: 'message'
                 }));
 
@@ -506,10 +496,8 @@ data: end
 
               test('should observe the fifth activity', () =>
                 expect(activitiesObserver).toHaveBeenNthCalledWith(6, {
-                  channelData: expect.anything(),
                   from: { id: 'bot' },
                   text: 'Goodbye!',
-                  timestamp: expect.any(String),
                   type: 'message'
                 }));
 
@@ -558,10 +546,8 @@ data: end
 
               test('should observe the sixth activity', () =>
                 expect(activitiesObserver).toHaveBeenNthCalledWith(7, {
-                  channelData: expect.anything(),
                   from: { id: 'bot' },
                   text: '再見！',
-                  timestamp: expect.any(String),
                   type: 'message'
                 }));
 
@@ -635,11 +621,9 @@ data: end
                           contentUrl: 'data:;base64,AQID'
                         }
                       ],
-                      channelData: expect.anything(),
                       from: { id: 'u-00001' },
                       id: postActivityObserver.mock.calls[0][0],
                       text: 'Here is the document.',
-                      timestamp: expect.any(String),
                       type: 'message'
                     }));
 
@@ -706,10 +690,8 @@ data: end
 
                   test('should observe the fourth activity', () =>
                     expect(activitiesObserver).toHaveBeenNthCalledWith(9, {
-                      channelData: expect.anything(),
                       from: { id: 'bot' },
                       text: 'Got it!',
-                      timestamp: expect.any(String),
                       type: 'message'
                     }));
                 });

--- a/packages/copilot-studio-direct-to-engine-chat-adapter/src/tests/toDirectLineJS/comprehensive.spec.ts
+++ b/packages/copilot-studio-direct-to-engine-chat-adapter/src/tests/toDirectLineJS/comprehensive.spec.ts
@@ -66,10 +66,8 @@ describe('with a TurnGenerator', () => {
       test('once', () => expect(activityObserver).toHaveBeenCalledTimes(1));
       test('with the activity', () =>
         expect(activityObserver).toHaveBeenNthCalledWith(1, {
-          channelData: expect.anything(),
           from: { id: 'bot' },
           text: 'Hello, World!',
-          timestamp: expect.any(String),
           type: 'message'
         }));
     });
@@ -124,19 +122,15 @@ describe('with a TurnGenerator', () => {
               test('twice', () => expect(activityObserver).toHaveBeenCalledTimes(3));
               test('with the outgoing activity', () =>
                 expect(activityObserver).toHaveBeenNthCalledWith(2, {
-                  channelData: expect.anything(),
                   from: { id: 'u-00001' },
                   id: postActivityObserver.mock.calls[0][0],
                   text: 'Aloha!',
-                  timestamp: expect.any(String),
                   type: 'message'
                 }));
               test('with the incoming activity', () =>
                 expect(activityObserver).toHaveBeenNthCalledWith(3, {
-                  channelData: expect.anything(),
                   from: { id: 'bot' },
                   text: 'Good morning.',
-                  timestamp: expect.any(String),
                   type: 'message'
                 }));
             });
@@ -180,19 +174,15 @@ describe('with a TurnGenerator', () => {
                     test('twice', () => expect(activityObserver).toHaveBeenCalledTimes(5));
                     test('with the outgoing activity', () =>
                       expect(activityObserver).toHaveBeenNthCalledWith(4, {
-                        channelData: expect.anything(),
                         from: { id: 'u-00001' },
                         id: postActivityObserver.mock.calls[0][0],
                         text: 'Goodbye.',
-                        timestamp: expect.any(String),
                         type: 'message'
                       }));
                     test('with the incoming activity', () =>
                       expect(activityObserver).toHaveBeenNthCalledWith(5, {
-                        channelData: expect.anything(),
                         from: { id: 'bot' },
                         text: 'Bye.',
-                        timestamp: expect.any(String),
                         type: 'message'
                       }));
                   });

--- a/packages/copilot-studio-direct-to-engine-chat-adapter/src/tests/toDirectLineJS/overlapPostActivity.spec.ts
+++ b/packages/copilot-studio-direct-to-engine-chat-adapter/src/tests/toDirectLineJS/overlapPostActivity.spec.ts
@@ -108,19 +108,15 @@ describe('with a TurnGenerator', () => {
               test('twice', () => expect(activityObserver).toHaveBeenCalledTimes(3));
               test('with the first outgoing activity', () =>
                 expect(activityObserver).toHaveBeenNthCalledWith(2, {
-                  channelData: expect.anything(),
                   from: { id: 'u-00001' },
                   id: firstPostActivityObserver.mock.calls[0][0],
                   text: 'Aloha!',
-                  timestamp: expect.any(String),
                   type: 'message'
                 }));
               test('with the incoming activity', () =>
                 expect(activityObserver).toHaveBeenNthCalledWith(3, {
-                  channelData: expect.anything(),
                   from: { id: 'bot' },
                   text: 'Goodbye.',
-                  timestamp: expect.any(String),
                   type: 'message'
                 }));
             });

--- a/packages/copilot-studio-direct-to-engine-chat-adapter/src/tests/toDirectLineJS/postActivity.noGreeting.spec.ts
+++ b/packages/copilot-studio-direct-to-engine-chat-adapter/src/tests/toDirectLineJS/postActivity.noGreeting.spec.ts
@@ -66,10 +66,8 @@ describe('with a TurnGenerator', () => {
       test('once', () => expect(activityObserver).toHaveBeenCalledTimes(1));
       test('with the activity', () =>
         expect(activityObserver).toHaveBeenNthCalledWith(1, {
-          channelData: expect.anything(),
           from: { id: 'bot' },
           text: 'Hello, World!',
-          timestamp: expect.any(String),
           type: 'message'
         }));
     });
@@ -123,20 +121,16 @@ describe('with a TurnGenerator', () => {
 
               test('with the incoming activity', () =>
                 expect(activityObserver).toHaveBeenNthCalledWith(1, {
-                  channelData: expect.anything(),
                   from: { id: 'bot' },
                   text: 'Hello, World!',
-                  timestamp: expect.any(String),
                   type: 'message'
                 }));
 
               test('with the outgoing activity', () =>
                 expect(activityObserver).toHaveBeenNthCalledWith(2, {
-                  channelData: expect.anything(),
                   from: { id: 'u-00001' },
                   id: postActivityObserver.mock.calls[0][0],
                   text: 'Aloha!',
-                  timestamp: expect.any(String),
                   type: 'message'
                 }));
             });

--- a/packages/copilot-studio-direct-to-engine-chat-adapter/src/tests/toDirectLineJS/webChatStyleSubscription.spec.ts
+++ b/packages/copilot-studio-direct-to-engine-chat-adapter/src/tests/toDirectLineJS/webChatStyleSubscription.spec.ts
@@ -79,10 +79,8 @@ describe('with a TurnGenerator', () => {
       await waitUntilGreetingReceived.promise;
 
       expect(activityObserver).toHaveBeenNthCalledWith(1, {
-        channelData: expect.anything(),
         from: { id: 'bot' },
         text: 'Hello, World!',
-        timestamp: expect.any(String),
         type: 'message'
       });
     });


### PR DESCRIPTION
The following patches are removed:

- Remove `activity.timestamp`
   - Yesterday: the service sometimes send timestamp, and sometimes don't, for consistency, we are removing all timestamps
   - Today: the service consistently send us timestamp, we no longer need to remove the timestamp
- Add `channelData['webchat:sequence-id']`
   - Yesterday: as timestamp is bogus, we can't rely on it for ordering, we are using sequence ID instead
   - Today: the timestamp is consistent, we can use it for ordering
   - Bottomline: subscribe endpoint does not send activity in a linear way, we need to use timestamp for ordering
- Side-effect `channelData` must be an object
   - In the spec, we don't actually care if `channelData` must exists or not, it can be removed
- Remove `activity.replyToId`
   - Yesterday: the service sometimes return a bogus `replyToId` (probably in the early of the conversation where there is nothing to reply to)
   - Today: if the service still return a bogus `replyToId`, we can remove it on Copilot Studio side
   - Bottomline: Copilot Studio has quite a few patches, we should unite them in one place and move them to chat adapter

The following patches are kept:

- Echo back activity
   - Today: service did not echo back the outgoing activity, thus the chat adapter do not have `activity.id`
   - What we did:
      1. Wait until the first response of the turn is received, or the turn ended
      2. Create a dummy ID
      3. Assign the ID to the outgoing activity
      4. Echo back the outgoing activity with ID
      5. Resolve the `postActivity()` call the activity ID
      6. Notes: `timestamp` is not filled
