### PR TITLE
Add experimental resume conversation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17764,6 +17764,7 @@
       },
       "devDependencies": {
         "@microsoft/applicationinsights-common": "^2.8.15",
+        "@testduet/given-when-then": "^0.1.0-main.334801c",
         "@testduet/wait-for": "^0.1.0",
         "@types/jest": "^29.5.3",
         "@types/uuid": "^9.0.7",
@@ -17781,6 +17782,16 @@
         "tsup": "^8.0.1",
         "type-fest": "^4.10.0",
         "typescript": "^5.8.3"
+      }
+    },
+    "packages/copilot-studio-direct-to-engine-chat-adapter/node_modules/@testduet/given-when-then": {
+      "version": "0.1.0-main.334801c",
+      "resolved": "https://registry.npmjs.org/@testduet/given-when-then/-/given-when-then-0.1.0-main.334801c.tgz",
+      "integrity": "sha512-Ah7OJI0NtN8x/uWqlMK5OJUT8qAAouFeBKYjVsDI5w54MKxAthAS0itUPetTiA1C8jdnYGTUweaB5u827JIvfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@testduet/given-when-then": "^0.1.0-main.334801c"
       }
     },
     "packages/copilot-studio-direct-to-engine-chat-adapter/node_modules/@types/retry": {

--- a/packages/copilot-studio-direct-to-engine-chat-adapter/CHANGELOG.md
+++ b/packages/copilot-studio-direct-to-engine-chat-adapter/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    - Fixed race conditions between give up my turn and post activity, by [@compulim](https://github.com/compulim), in PR [#65](https://github.com/compulim/conversational-ai-chat-sdk/pull/65)
 - (Experimental) Added experimental /subscribe endpoint, by [@compulim](https://github.com/compulim), in PR [#62](https://github.com/compulim/conversational-ai-chat-sdk/pull/62) and [#64](https://github.com/compulim/conversational-ai-chat-sdk/pull/64)
 - Added `*/*;q=0.8` to accept header, by [@compulim](https://github.com/compulim), in PR [#70](https://github.com/compulim/conversational-ai-chat-sdk/pull/70)
-- (Experimental) Added `createFetchArguments` for custom fetch calls, by [@compulim](https://github.com/compulim), in PR [#XXX](https://github.com/compulim/conversational-ai-chat-sdk/pull/XXX)
+- (Experimental) Added `createFetchArguments` for custom fetch calls, by [@compulim](https://github.com/compulim), in PR [#71](https://github.com/compulim/conversational-ai-chat-sdk/pull/71)
+- (Experimental) Added `resumeConversationId` to resume conversation, by [@compulim](https://github.com/compulim), in PR [#75](https://github.com/compulim/conversational-ai-chat-sdk/pull/75)
 
 ## [0.0.0] - 2023-08-19
 

--- a/packages/copilot-studio-direct-to-engine-chat-adapter/package.json
+++ b/packages/copilot-studio-direct-to-engine-chat-adapter/package.json
@@ -75,6 +75,7 @@
   },
   "devDependencies": {
     "@microsoft/applicationinsights-common": "^2.8.15",
+    "@testduet/given-when-then": "^0.1.0-main.334801c",
     "@testduet/wait-for": "^0.1.0",
     "@types/jest": "^29.5.3",
     "@types/uuid": "^9.0.7",

--- a/packages/copilot-studio-direct-to-engine-chat-adapter/src/experimental/createHalfDuplexChatAdapterWithSubscribe.ts
+++ b/packages/copilot-studio-direct-to-engine-chat-adapter/src/experimental/createHalfDuplexChatAdapterWithSubscribe.ts
@@ -82,10 +82,20 @@ export default function createHalfDuplexChatAdapter(
       telemetry: init.telemetry
     });
 
-    yield* api.startNewConversation({
-      emitStartConversationEvent: init.emitStartConversationEvent ?? true,
-      locale: init.locale
-    });
+    // TODO: Unsure if this is the best pattern for resuming a conversation.
+    //       When resuming a conversation, the caller will still need to go through the first and empty round of activities
+    //       After iterating the empty round, they will receive the executeTurn() function.
+    if (init.experimental_resumeConversationId) {
+      await api.experimental_resumeConversation({
+        conversationId: init.experimental_resumeConversationId,
+        correlationId: init.telemetry?.correlationId
+      });
+    } else {
+      yield* api.startNewConversation({
+        emitStartConversationEvent: init.emitStartConversationEvent ?? true,
+        locale: init.locale
+      });
+    }
 
     return createExecuteTurn(api, init);
   })();

--- a/packages/copilot-studio-direct-to-engine-chat-adapter/src/experimental/tests/resumeConversation.spec.ts
+++ b/packages/copilot-studio-direct-to-engine-chat-adapter/src/experimental/tests/resumeConversation.spec.ts
@@ -1,0 +1,106 @@
+import { scenario } from '@testduet/given-when-then';
+import { readableStreamFrom } from 'iter-fest';
+import { setupServer } from 'msw/node';
+
+import mockServer from '../../private/DirectToEngineChatAdapterAPI/DirectToEngineChatAdapterAPIWithExecuteViaSubscribe/private/mockServer';
+import { type Strategy } from '../../types/Strategy';
+import createHalfDuplexChatAdapterWithSubscribe from '../createHalfDuplexChatAdapterWithSubscribe';
+
+const encoder = new TextEncoder();
+const server = setupServer();
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+jest.setTimeout(1_000);
+
+scenario('resume conversation', bdd => {
+  bdd
+    .given(
+      'an AbortController',
+      () => ({ abortController: new AbortController() }),
+      ({ abortController }) => abortController.abort()
+    )
+    .and('a strategy', ({ abortController }) => ({
+      abortController,
+      strategy: {
+        experimental_prepareSubscribeActivities: jest.fn(async () => ({
+          baseURL: new URL('http://test/conversations')
+        })),
+        prepareExecuteTurn: jest.fn(async () => ({ baseURL: new URL('http://test/conversations') })),
+        prepareStartNewConversation: jest.fn(async () => ({ baseURL: new URL('http://test/conversations') }))
+      } satisfies Strategy
+    }))
+    .and('an instance of msw', ({ abortController, strategy }) => {
+      const serverMock = mockServer(server);
+
+      serverMock.httpPostSubscribe.createResponseStreamForSSE.mockImplementationOnce(async () =>
+        readableStreamFrom([
+          encoder.encode(
+            `event: activity\ndata: ${JSON.stringify({
+              from: { id: 'bot' },
+              text: 'Bot first message',
+              type: 'message'
+            })}\n\n`
+          )
+        ])
+      );
+
+      serverMock.httpPostExecute.createResponseStreamForSSE.mockImplementationOnce(async () =>
+        readableStreamFrom([encoder.encode(`event: end\ndata: end\n\n`)])
+      );
+
+      return { abortController, serverMock, strategy };
+    })
+    .and('the chat adapter', ({ abortController, serverMock, strategy }) => {
+      const onActivity = jest.fn();
+      const chatAdapter = createHalfDuplexChatAdapterWithSubscribe(strategy, {
+        experimental_resumeConversationId: 'c-00001'
+      });
+
+      return { abortController, chatAdapter, onActivity, serverMock, strategy };
+    })
+    .when('iterated', async ({ chatAdapter }) => chatAdapter.next())
+    .then('should return no activities', (_, result) =>
+      expect(result).toEqual({ done: true, value: expect.any(Function) })
+    )
+    .and('HTTP start conversation should not have been called', ({ serverMock }) =>
+      expect(serverMock.httpPostConversation.responseResolver).toHaveBeenCalledTimes(0)
+    )
+    .and('strategy.prepareStartNewConversation should not have been called', ({ strategy }) =>
+      expect(strategy.prepareStartNewConversation).toHaveBeenCalledTimes(0)
+    )
+    .when('execute turn is called', async (_, result) => {
+      if (!result.done) {
+        throw new Error();
+      }
+
+      const iterator = result.value({ from: { id: 'user' }, text: 'User first message', type: 'message' });
+
+      return { iterator, result: iterator.next() };
+    })
+    .then('strategy.prepareExecuteTurn should have been called once', ({ strategy }) =>
+      expect(strategy.prepareExecuteTurn).toHaveBeenCalledTimes(1)
+    )
+    .and('HTTP execute should have been called with conversation ID', ({ serverMock }) => {
+      expect(serverMock.httpPostExecute.responseResolver.mock.calls[0][0].request.url).toBe(
+        'http://test/conversations/c-00001'
+      );
+
+      expect(
+        serverMock.httpPostExecute.responseResolver.mock.calls[0][0].request.headers.get('x-ms-conversationid')
+      ).toBe('c-00001');
+    })
+    .and('HTTP execute should have been called with the outgoing activity', async ({ serverMock }) =>
+      expect(serverMock.httpPostExecute.responseResolver.mock.calls[0][0].request.json()).resolves.toEqual({
+        activity: { from: { id: 'user' }, text: 'User first message', type: 'message' }
+      })
+    )
+    .and('HTTP execute should return an activity', (_, { result }) =>
+      expect(result).resolves.toEqual({
+        done: false,
+        value: { from: { id: 'bot' }, text: 'Bot first message', type: 'message' }
+      })
+    );
+});

--- a/packages/copilot-studio-direct-to-engine-chat-adapter/src/private/DirectToEngineChatAdapterAPI/DirectToEngineChatAdapterAPI.ts
+++ b/packages/copilot-studio-direct-to-engine-chat-adapter/src/private/DirectToEngineChatAdapterAPI/DirectToEngineChatAdapterAPI.ts
@@ -1,5 +1,6 @@
 import { parse } from 'valibot';
 import {
+  type ExperimentalResumeConversationInit,
   type HalfDuplexChatAdapterAPI,
   type StartNewConversationInit
 } from '../../private/types/HalfDuplexChatAdapterAPI';
@@ -87,6 +88,25 @@ export class DirectToEngineChatAdapterAPIImpl implements HalfDuplexChatAdapterAP
         this.#busy = false;
       }
     }.call(this);
+  }
+
+  /** @deprecated Experimental */
+  public async experimental_resumeConversation(init: ExperimentalResumeConversationInit): Promise<void> {
+    if (this.#busy) {
+      const error = new Error('Another operation is in progress.');
+
+      this.#telemetry?.trackException?.(error, {
+        handledAt: 'DirectToEngineChatAdapterAPI.experimental_resumeConversation'
+      });
+
+      throw error;
+    }
+
+    this.#busy = true;
+
+    await this.#session.experimental_resumeConversation(init.conversationId);
+
+    this.#busy = false;
   }
 }
 

--- a/packages/copilot-studio-direct-to-engine-chat-adapter/src/private/DirectToEngineChatAdapterAPI/DirectToEngineChatAdapterAPIWithExecuteViaSubscribe.ts
+++ b/packages/copilot-studio-direct-to-engine-chat-adapter/src/private/DirectToEngineChatAdapterAPI/DirectToEngineChatAdapterAPIWithExecuteViaSubscribe.ts
@@ -1,6 +1,9 @@
 import { parse } from 'valibot';
 import isAbortError from '../../private/isAbortError';
-import { type StartNewConversationInit } from '../../private/types/HalfDuplexChatAdapterAPI';
+import {
+  type ExperimentalResumeConversationInit,
+  type StartNewConversationInit
+} from '../../private/types/HalfDuplexChatAdapterAPI';
 import { type Activity } from '../../types/Activity';
 import { type Strategy } from '../../types/Strategy';
 import { type Telemetry } from '../../types/Telemetry';
@@ -101,6 +104,13 @@ export default class DirectToEngineChatAdapterAPIWithExecuteViaSubscribe extends
       // After first startNewConversation() is done, start the subscribe.
       this.#startSubscribe();
     }.call(this);
+  }
+
+  /** @deprecated Experimental */
+  public async experimental_resumeConversation(init: ExperimentalResumeConversationInit): Promise<void> {
+    await super.experimental_resumeConversation(init);
+
+    this.#startSubscribe();
   }
 
   public executeTurn(activity?: Activity | undefined): AsyncIterableIterator<Activity> {

--- a/packages/copilot-studio-direct-to-engine-chat-adapter/src/private/DirectToEngineChatAdapterAPI/DirectToEngineChatAdapterAPIWithExecuteViaSubscribe/resumeConversation.alreadyStarted.spec.ts
+++ b/packages/copilot-studio-direct-to-engine-chat-adapter/src/private/DirectToEngineChatAdapterAPI/DirectToEngineChatAdapterAPIWithExecuteViaSubscribe/resumeConversation.alreadyStarted.spec.ts
@@ -1,0 +1,75 @@
+import { scenario } from '@testduet/given-when-then';
+import { readableStreamFrom } from 'iter-fest';
+import { setupServer } from 'msw/node';
+import DirectToEngineChatAdapterAPIWithExecuteViaSubscribe from '../DirectToEngineChatAdapterAPIWithExecuteViaSubscribe';
+import mockServer from './private/mockServer';
+
+const encoder = new TextEncoder();
+const server = setupServer();
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+jest.setTimeout(1_000);
+
+function ignoreUnhandledRejection<T extends Promise<unknown>>(promise: T): T {
+  promise.catch(() => {});
+
+  return promise;
+}
+
+scenario('resume conversation after started', bdd => {
+  bdd
+    .given(
+      'an AbortController',
+      () => ({ abortController: new AbortController() }),
+      ({ abortController }) => abortController.abort()
+    )
+    .and('an instance of msw', ({ abortController }) => {
+      const serverMock = mockServer(server);
+
+      serverMock.httpPostConversation.createResponseStreamForSSE.mockImplementationOnce(async () =>
+        readableStreamFrom([encoder.encode(`event: end\ndata:end\n\n`)])
+      );
+
+      serverMock.httpPostSubscribe.createResponseStreamForSSE.mockImplementationOnce(async () =>
+        readableStreamFrom([encoder.encode(`event: end\ndata:end\n\n`)])
+      );
+
+      return { abortController, serverMock };
+    })
+    .and('the API', ({ abortController, serverMock }) => {
+      const onActivity = jest.fn();
+      const telemetry = { trackException: jest.fn() };
+
+      const api = new DirectToEngineChatAdapterAPIWithExecuteViaSubscribe(serverMock.strategy, {
+        onActivity,
+        retry: { retries: 0 },
+        signal: abortController.signal,
+        telemetry
+      });
+
+      return { abortController, api, onActivity, serverMock, telemetry };
+    })
+    .when('startConversation() is called', ({ api }) =>
+      api.startNewConversation({ emitStartConversationEvent: true }).next()
+    )
+    .then('should return no activities', (_, result) => expect(result).toEqual({ done: true, value: undefined }))
+    .when('resumeConversation() is called with conversation ID "c-00001"', ({ api }) => ({
+      promise: ignoreUnhandledRejection(api.experimental_resumeConversation({ conversationId: 'c-00001' }))
+    }))
+    .then('should throw', (_, { promise }) =>
+      expect(() => promise).rejects.toThrowError('Conversation has already started, cannot resume conversation')
+    )
+    .and('telemetry.trackException should have been called once', ({ telemetry }) =>
+      expect(telemetry.trackException).toHaveBeenCalledTimes(1)
+    )
+    .and('telemetry.trackException should have been called with the error', ({ telemetry }) => {
+      expect(telemetry.trackException.mock.calls[0][0]).toBeInstanceOf(Error);
+      expect(telemetry.trackException.mock.calls[0][0]).toHaveProperty(
+        'message',
+        'Conversation has already started, cannot resume conversation'
+      );
+    });
+});

--- a/packages/copilot-studio-direct-to-engine-chat-adapter/src/private/DirectToEngineChatAdapterAPI/DirectToEngineChatAdapterAPIWithExecuteViaSubscribe/resumeConversation.busy.spec.ts
+++ b/packages/copilot-studio-direct-to-engine-chat-adapter/src/private/DirectToEngineChatAdapterAPI/DirectToEngineChatAdapterAPIWithExecuteViaSubscribe/resumeConversation.busy.spec.ts
@@ -1,0 +1,72 @@
+import { scenario } from '@testduet/given-when-then';
+import { readableStreamFrom } from 'iter-fest';
+import { setupServer } from 'msw/node';
+import DirectToEngineChatAdapterAPIWithExecuteViaSubscribe from '../DirectToEngineChatAdapterAPIWithExecuteViaSubscribe';
+import hasResolved from './private/hasResolved';
+import mockServer from './private/mockServer';
+
+const encoder = new TextEncoder();
+const server = setupServer();
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+jest.setTimeout(1_000);
+
+function ignoreUnhandledRejection<T extends Promise<unknown>>(promise: T): T {
+  promise.catch(() => {});
+
+  return promise;
+}
+
+scenario('resume conversation when busy', bdd => {
+  bdd
+    .given(
+      'an AbortController',
+      () => ({ abortController: new AbortController() }),
+      ({ abortController }) => abortController.abort()
+    )
+    .and('an instance of msw', ({ abortController }) => {
+      const serverMock = mockServer(server);
+
+      // Start conversation never return, causing the APISession to be busy.
+      serverMock.httpPostConversation.createResponseStreamForSSE.mockImplementationOnce(() => new Promise(() => {}));
+
+      serverMock.httpPostSubscribe.createResponseStreamForSSE.mockImplementationOnce(async () =>
+        readableStreamFrom([encoder.encode(`event: end\ndata:end\n\n`)])
+      );
+
+      return { abortController, serverMock };
+    })
+    .and('the API', ({ abortController, serverMock }) => {
+      const onActivity = jest.fn();
+      const telemetry = { trackException: jest.fn() };
+
+      const api = new DirectToEngineChatAdapterAPIWithExecuteViaSubscribe(serverMock.strategy, {
+        onActivity,
+        retry: { retries: 0 },
+        signal: abortController.signal,
+        telemetry
+      });
+
+      return { abortController, api, onActivity, serverMock, telemetry };
+    })
+    .when('startConversation() is called', ({ api }) => ({
+      promise: ignoreUnhandledRejection(api.startNewConversation({ emitStartConversationEvent: true }).next())
+    }))
+    .then('should not resolve', (_, { promise }) => expect(hasResolved(promise)).resolves.toBe(false))
+    .when('resumeConversation() is called with conversation ID "c-00001"', ({ api }) => ({
+      promise: ignoreUnhandledRejection(api.experimental_resumeConversation({ conversationId: 'c-00001' }))
+    }))
+    .then('should throw', (_, { promise }) =>
+      expect(() => promise).rejects.toThrowError('Another operation is in progress.')
+    )
+    .and('telemetry.trackException should have been called once', ({ telemetry }) =>
+      expect(telemetry.trackException).toHaveBeenCalledTimes(1)
+    )
+    .and('telemetry.trackException should have been called with the error', ({ telemetry }) => {
+      expect(telemetry.trackException.mock.calls[0][0]).toBeInstanceOf(Error);
+      expect(telemetry.trackException.mock.calls[0][0]).toHaveProperty('message', 'Another operation is in progress.');
+    });
+});

--- a/packages/copilot-studio-direct-to-engine-chat-adapter/src/private/DirectToEngineChatAdapterAPI/DirectToEngineChatAdapterAPIWithExecuteViaSubscribe/resumeConversation.spec.ts
+++ b/packages/copilot-studio-direct-to-engine-chat-adapter/src/private/DirectToEngineChatAdapterAPI/DirectToEngineChatAdapterAPIWithExecuteViaSubscribe/resumeConversation.spec.ts
@@ -1,0 +1,76 @@
+import { scenario } from '@testduet/given-when-then';
+import { waitFor } from '@testduet/wait-for';
+import { readableStreamFrom } from 'iter-fest';
+import { setupServer } from 'msw/node';
+import DirectToEngineChatAdapterAPIWithExecuteViaSubscribe from '../DirectToEngineChatAdapterAPIWithExecuteViaSubscribe';
+import mockServer from './private/mockServer';
+
+const encoder = new TextEncoder();
+const server = setupServer();
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+jest.setTimeout(1_000);
+
+// TODO: Fix leaking/lingering tests.
+scenario('resume conversation', bdd => {
+  bdd
+    .given(
+      'an AbortController',
+      () => ({ abortController: new AbortController() }),
+      ({ abortController }) => abortController.abort()
+    )
+    .and('an instance of msw', ({ abortController }) => {
+      const serverMock = mockServer(server);
+
+      serverMock.httpPostSubscribe.createResponseStreamForSSE.mockImplementationOnce(async () =>
+        readableStreamFrom([
+          encoder.encode(
+            `event: activity\ndata: ${JSON.stringify({
+              from: { id: 'bot' },
+              text: 'Bot first message',
+              type: 'message'
+            })}\n\n`
+          )
+        ])
+      );
+
+      return { abortController, serverMock };
+    })
+    .and('the API', ({ abortController, serverMock }) => {
+      const onActivity = jest.fn();
+      const api = new DirectToEngineChatAdapterAPIWithExecuteViaSubscribe(serverMock.strategy, {
+        onActivity,
+        retry: { retries: 0 },
+        signal: abortController.signal
+      });
+
+      return { abortController, api, onActivity, serverMock };
+    })
+    .when('resumeConversation() is called with conversation ID "c-00001"', async ({ api }) => {
+      await api.experimental_resumeConversation({ conversationId: 'c-00001' });
+    })
+    .then('HTTP /subcribe should have been called', ({ serverMock }) =>
+      // After successfully resumed the conversation, the /subscribe endpoint should have been called immediately.
+      waitFor(() => expect(serverMock.httpPostSubscribe.responseResolver).toHaveBeenCalledTimes(1))
+    )
+    .and('onActivity() should have called', ({ onActivity }) =>
+      // After successfully resumed the conversation, the /subscribe endpoint should have send the activity and signaled via onActivity() callback.
+      waitFor(() => expect(onActivity).toHaveBeenCalledTimes(1))
+    )
+    .when('executeTurn() is called to give up the turn and returning the first iterated item', async ({ api }) => {
+      for await (const activity of api.executeTurn()) {
+        // Returning the first activity from the subscribe call.
+        return activity;
+      }
+    })
+    .then('return value should have the activity', (_, activity) =>
+      expect(activity).toEqual({
+        from: { id: 'bot' },
+        text: 'Bot first message',
+        type: 'message'
+      })
+    );
+});

--- a/packages/copilot-studio-direct-to-engine-chat-adapter/src/private/types/HalfDuplexChatAdapterAPI.ts
+++ b/packages/copilot-studio-direct-to-engine-chat-adapter/src/private/types/HalfDuplexChatAdapterAPI.ts
@@ -6,6 +6,12 @@ export type StartNewConversationInit = {
   locale?: string | undefined;
 };
 
+/** @deprecated Experimental */
+export type ExperimentalResumeConversationInit = {
+  conversationId: string;
+  correlationId?: string | undefined;
+};
+
 export type ExecuteTurnInit = {
   correlationId?: string | undefined;
 };
@@ -13,4 +19,7 @@ export type ExecuteTurnInit = {
 export interface HalfDuplexChatAdapterAPI {
   startNewConversation(init: StartNewConversationInit): AsyncIterableIterator<Activity>;
   executeTurn(activity?: Activity | undefined): AsyncIterableIterator<Activity>;
+
+  /** @deprecated Experimental */
+  experimental_resumeConversation(init: ExperimentalResumeConversationInit): Promise<void>;
 }

--- a/packages/copilot-studio-direct-to-engine-chat-adapter/src/tests/createHalfDuplexChatAdapter/resumeConversation.spec.ts
+++ b/packages/copilot-studio-direct-to-engine-chat-adapter/src/tests/createHalfDuplexChatAdapter/resumeConversation.spec.ts
@@ -1,0 +1,118 @@
+import { scenario } from '@testduet/given-when-then';
+import { readableStreamFrom } from 'iter-fest';
+import { setupServer } from 'msw/node';
+
+import createHalfDuplexChatAdapter from '../../createHalfDuplexChatAdapter';
+import mockServer from '../../private/DirectToEngineChatAdapterAPI/DirectToEngineChatAdapterAPIWithExecuteViaSubscribe/private/mockServer';
+import { type Strategy } from '../../types/Strategy';
+
+const encoder = new TextEncoder();
+const server = setupServer();
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+jest.setTimeout(1_000);
+
+// TODO: Fix leaking/lingering tests.
+scenario('resume conversation', bdd => {
+  bdd
+    .given(
+      'an AbortController',
+      () => ({ abortController: new AbortController() }),
+      ({ abortController }) => abortController.abort()
+    )
+    .and('a strategy', ({ abortController }) => ({
+      abortController,
+      strategy: {
+        prepareExecuteTurn: jest.fn(() =>
+          Promise.resolve({
+            baseURL: new URL('http://test/?api=execute#2'),
+            body: { dummy: 'dummy' },
+            headers: new Headers({ 'x-dummy': 'dummy' }),
+            transport: 'auto'
+          })
+        ),
+        prepareStartNewConversation: jest.fn(() =>
+          Promise.resolve({
+            baseURL: new URL('http://test/?api=start#1'),
+            body: { dummy: 'dummy' },
+            headers: new Headers({ 'x-dummy': 'dummy' }),
+            transport: 'auto'
+          })
+        )
+      } satisfies Strategy
+    }))
+    .and('an instance of msw', ({ abortController, strategy }) => {
+      const serverMock = mockServer(server);
+
+      serverMock.httpPostExecute.createResponseStreamForSSE.mockImplementationOnce(async () =>
+        readableStreamFrom([
+          encoder.encode(
+            `event: activity\ndata: ${JSON.stringify({
+              from: { id: 'bot' },
+              text: 'Bot first message',
+              type: 'message'
+            })}\n\nevent: end\ndata: end\n\n`
+          )
+        ])
+      );
+
+      return { abortController, serverMock, strategy };
+    })
+    .and('the chat adapter', ({ abortController, serverMock, strategy }) => {
+      const onActivity = jest.fn();
+      const chatAdapter = createHalfDuplexChatAdapter(strategy, { experimental_resumeConversationId: 'c-00001' });
+
+      return { abortController, chatAdapter, onActivity, serverMock, strategy };
+    })
+    .when('iterated', async ({ chatAdapter }) => chatAdapter.next())
+    .then('should return no activities', (_, result) =>
+      expect(result).toEqual({ done: true, value: expect.any(Function) })
+    )
+    .and('HTTP start conversation should not have been called', ({ serverMock }) =>
+      expect(serverMock.httpPostConversation.responseResolver).toHaveBeenCalledTimes(0)
+    )
+    .and('strategy.prepareStartNewConversation should not have been called', ({ strategy }) =>
+      expect(strategy.prepareStartNewConversation).toHaveBeenCalledTimes(0)
+    )
+    .when('execute turn is called', async (_, result) => {
+      if (!result.done) {
+        throw new Error();
+      }
+
+      const iterator = result.value({ from: { id: 'user' }, text: 'User first message', type: 'message' });
+
+      return { iterator, result: iterator.next() };
+    })
+    .then('strategy.prepareExecuteTurn should have been called once', ({ strategy }) =>
+      expect(strategy.prepareExecuteTurn).toHaveBeenCalledTimes(1)
+    )
+    .and('HTTP execute should have been called once', ({ serverMock }) =>
+      expect(serverMock.httpPostExecute.responseResolver).toHaveBeenCalledTimes(1)
+    )
+    .and('HTTP execute should have been called with conversation ID', async ({ serverMock }) => {
+      expect(serverMock.httpPostExecute.responseResolver.mock.calls[0][0].request.url).toBe(
+        'http://test/conversations/c-00001?api=execute#2'
+      );
+
+      expect(
+        serverMock.httpPostExecute.responseResolver.mock.calls[0][0].request.headers.get('x-ms-conversationid')
+      ).toBe('c-00001');
+    })
+    .and('HTTP execute should have been called with the outgoing activity', async ({ serverMock }) =>
+      expect(serverMock.httpPostExecute.responseResolver.mock.calls[0][0].request.json()).resolves.toEqual({
+        dummy: 'dummy',
+        activity: { from: { id: 'user' }, text: 'User first message', type: 'message' }
+      })
+    )
+    .and('HTTP execute should return an activity', (_, { result }) =>
+      expect(result).resolves.toEqual({
+        done: false,
+        value: { from: { id: 'bot' }, text: 'Bot first message', type: 'message' }
+      })
+    )
+    .when('iterate again', (_, { iterator }) => iterator.next())
+    .then('should return done', (_, result) => expect(result).toEqual({ done: true, value: expect.any(Function) }));
+});


### PR DESCRIPTION
## Changelog

### Added

- (Experimental) Added `resumeConversationId` to resume conversation, by [@compulim](https://github.com/compulim), in PR [#75](https://github.com/compulim/conversational-ai-chat-sdk/pull/75)
