### PR TITLE
Ability to override content-type request header

### DIFF
--- a/packages/copilot-studio-direct-to-engine-chat-adapter/src/private/DirectToEngineChatAdapterAPI/private/createFetchArguments.ts
+++ b/packages/copilot-studio-direct-to-engine-chat-adapter/src/private/DirectToEngineChatAdapterAPI/private/createFetchArguments.ts
@@ -29,7 +29,7 @@ export default function createFetchArguments(
       ? 'application/json,*/*;q=0.8'
       : 'text/event-stream,application/json;q=0.9,*/*;q=0.8'
   );
-  headers.set('content-type', 'application/json');
+  !headers.get('content-type') && headers.set('content-type', 'application/json');
   headers.set(
     CHAT_ADAPTER_HEADER_NAME,
     new URLSearchParams([['version', NPM_PACKAGE_VERSION]] satisfies string[][]).toString()


### PR DESCRIPTION
As part of json to yaml work, the content can be mix of json and yaml, which needs to send content-type header with `application/json+yaml`.